### PR TITLE
Add support for Trianco Activair High Temp 9kw

### DIFF
--- a/custom_components/aqua_temp/common/consts.py
+++ b/custom_components/aqua_temp/common/consts.py
@@ -41,6 +41,7 @@ PRODUCT_IDS = [
     "1669159229372477440",  # Aqua Temp
     "1650758828508766208",  # Aqua Temp
     "1664085465655808000",  # Aqua Temp
+    "1501438265440362496",  # Trianco Activair High Temp 9kw
 ]
 
 MANUAL_MUTE_AUTO = "0"

--- a/custom_components/aqua_temp/parameters/entity_description.1501438265440362496.json
+++ b/custom_components/aqua_temp/parameters/entity_description.1501438265440362496.json
@@ -101,6 +101,13 @@
     "unit_of_measurement": "\u00b0C"
   },
   {
+    "key": "T15",
+    "name": "Low Pressure [T15]",
+    "platform": "sensor",
+    "device_class": "pressure",
+    "unit_of_measurement": "bar"
+  },
+  {
     "key": "T27",
     "name": "speed of fan motor1 [T27]",
     "platform": "sensor",

--- a/custom_components/aqua_temp/parameters/entity_description.1501438265440362496.json
+++ b/custom_components/aqua_temp/parameters/entity_description.1501438265440362496.json
@@ -122,6 +122,13 @@
     "unit_of_measurement": "A"
   },
   {
+    "key": "T39",
+    "name": "Water Flow [T39]",
+    "platform": "sensor",
+    "device_class": "volume_flow_rate",
+    "unit_of_measurement": "m³/h"
+  },
+  {
     "key": "2014",
     "name": "AT Target Temp",
     "platform": "sensor",

--- a/custom_components/aqua_temp/parameters/entity_description.1501438265440362496.json
+++ b/custom_components/aqua_temp/parameters/entity_description.1501438265440362496.json
@@ -1,0 +1,144 @@
+[
+  {
+    "key": "Power",
+    "name": "Power",
+    "platform": "binary_sensor",
+    "device_class": "power",
+    "on_value": "1"
+  },
+  {
+    "key": "Mode",
+    "name": "Mode",
+    "platform": null
+  },
+  {
+    "key": "Set_Temp",
+    "name": "Set_Temp",
+    "platform": null
+  },
+  {
+    "key": "R01",
+    "name": "DHW Target Temp [R01]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R02",
+    "name": "Heating Target Temp [R02]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R08",
+    "name": "Min. cool [R08]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R09",
+    "name": "Max. cool [R09]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R10",
+    "name": "Min. heat [R10]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R11",
+    "name": "Max. heat [R11]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R36",
+    "name": "Min. DHW [R36]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "R37",
+    "name": "Max. DHW [R37]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "T01",
+    "name": "Inlet water temp. [T01]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "T02",
+    "name": "Outlet water Temp. [T02]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "T04",
+    "name": "Ambient Temp. [T04]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "T08",
+    "name": "DHW tank Temp. [T08]",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "T27",
+    "name": "speed of fan motor1 [T27]",
+    "platform": "sensor",
+    "device_class": null,
+    "unit_of_measurement": "rpm"
+  },
+  {
+    "key": "T34",
+    "name": "AC input voltage [T34]",
+    "platform": "sensor",
+    "device_class": "voltage",
+    "unit_of_measurement": "V"
+  },
+  {
+    "key": "T35",
+    "name": "AC input current [T35]",
+    "platform": "sensor",
+    "device_class": "current",
+    "unit_of_measurement": "A"
+  },
+  {
+    "key": "2014",
+    "name": "AT Target Temp",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  },
+  {
+    "key": "compensate_slope",
+    "name": "AT Compensate Slope",
+    "platform": "sensor",
+    "device_class": null
+  },
+  {
+    "key": "compensate_offset",
+    "name": "AT Compensate Offset",
+    "platform": "sensor",
+    "device_class": "temperature",
+    "unit_of_measurement": "\u00b0C"
+  }
+]

--- a/custom_components/aqua_temp/parameters/mapping.1501438265440362496.json
+++ b/custom_components/aqua_temp/parameters/mapping.1501438265440362496.json
@@ -1,0 +1,37 @@
+{
+    "mode": "Mode",
+    "power": "Power",
+    "temperature": "Set_Temp",
+    "fan": "Manual-mute",
+    "current_temperature": "T02",
+    "hvac_modes": {
+      "off": {
+        "set": null,
+        "target": null,
+        "minimum": null,
+        "maximum": null
+      },
+      "cool": {
+        "set": "0",
+        "target": "R01",
+        "minimum": "R36",
+        "maximum": "R37"
+      },
+      "heat": {
+        "set": "1",
+        "target": "compensate_offset",
+        "minimum": "R10",
+        "maximum": "R11"
+      },
+       "auto": {
+        "set": "3",
+        "target": "compensate_offset",
+        "minimum": "R10",
+        "maximum": "R11"
+      }
+    },
+    "fan_modes": {
+      "auto": "0",
+      "low": "1"
+    }
+  }


### PR DESCRIPTION
Hi,

I don't know if this is something you want to merge, but I added a product ID for a Trianco heat pump (which I'm assuming is a re-branded AquaTemp and uses the Wamlink app (written by the same developers)). It's a home heatpump that does domestic hot water (DHW) and central heating, so I've mapped the HVAC modes so that:

Cool -> DHW
Heat -> Central heating
Auto -> DHW & Heat

It also assumes you're using the ambient temperature compensation feature.
The entity description file just contains the codes that I was interested in, so there are more that could be added.

:-)